### PR TITLE
feat(Subtitle): flag to turn them on. Default is off

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,14 @@ registerElement("exoplayer", () => require("nativescript-exoplayer").Video);
 
 Set the video file to play, for best performance use local video files if possible. The file must adhere to the platforms accepted video formats. For reference check the platform specs on playing videos.
 
+- **enableSubtitles**
+
+By default, subtitle support is off. Use this flag to turn them on.
+
 - **subtitles**
 
 Set `.srt` file with subtitles for given video. This can be local file or internet url. Currently only `.srt` format is supported.
+
 
 - **autoplay - (boolean)** - *optional*
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-exoplayer",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "main": "videoplayer",
   "typings": "index.d.ts",
   "description": "A NativeScript plugin that uses the ExoPlayer video player on Android to play local and remote videos.",

--- a/videoplayer-common.ts
+++ b/videoplayer-common.ts
@@ -77,6 +77,12 @@ export const srcProperty = new Property<Video, any>({
 });
 srcProperty.register(Video);
 
+export const enableSubtitlesProperty = new Property<Video, boolean>({
+    name: "enableSubtitles",
+    valueConverter: booleanConverter,
+});
+enableSubtitlesProperty.register(Video);
+
 export const subtitlesProperty = new Property<Video, any>({
     name: "subtitles",
     valueChanged: onSubtitlesPropertyChanged

--- a/videoplayer-common.ts
+++ b/videoplayer-common.ts
@@ -67,6 +67,8 @@ export class Video extends View {
     public loop: boolean = false; /// whether the video loops the playback after extends
     public muted: boolean = false;
     public fill: boolean = false;
+
+    public enableSubtitles: boolean;
 }
 
 export const srcProperty = new Property<Video, any>({

--- a/videoplayer.android.ts
+++ b/videoplayer.android.ts
@@ -110,10 +110,12 @@ export class Video extends videoCommon.Video {
 		this._textureView.requestFocus();
 		nativeView.addView(this._textureView);
 
-		this._subtitlesView = new com.google.android.exoplayer2.ui.SubtitleView(this._context);
-		this._subtitlesView.setUserDefaultStyle();
-		this._subtitlesView.setUserDefaultTextSize();
-		nativeView.addView(this._subtitlesView);
+		if (this.enableSubtitles) {
+			this._subtitlesView = new com.google.android.exoplayer2.ui.SubtitleView(this._context);
+			this._subtitlesView.setUserDefaultStyle();
+			this._subtitlesView.setUserDefaultTextSize();
+			nativeView.addView(this._subtitlesView);
+		}	
 
 
 		return nativeView;
@@ -360,8 +362,10 @@ export class Video extends videoCommon.Video {
 				this._setupTextureSurface();
 			}
 
-			//subtitles view
-			this.mediaPlayer.setTextOutput(this._subtitlesView);
+			if (this.enableSubtitles) {
+				//subtitles view
+				this.mediaPlayer.setTextOutput(this._subtitlesView);
+			}	
 
 
 			let dsf = new com.google.android.exoplayer2.upstream.DefaultDataSourceFactory(this._context, "NativeScript", bm);
@@ -485,11 +489,13 @@ export class Video extends videoCommon.Video {
 	}
 
 	public _updateSubtitles(subtitlesSrc: any): void {
-		this._subtitlesSrc = subtitlesSrc;
-		if (this.mediaPlayer != null) {
-			this.preSeekTime = this.mediaPlayer.getCurrentPosition();
-		}
-		this._openVideo()
+		if (this.enableSubtitles) {
+			this._subtitlesSrc = subtitlesSrc;
+			if (this.mediaPlayer != null) {
+				this.preSeekTime = this.mediaPlayer.getCurrentPosition();
+			}
+			this._openVideo();
+		}	
 	}
 
 	public play(): void {

--- a/videoplayer.ios.ts
+++ b/videoplayer.ios.ts
@@ -39,9 +39,11 @@ export class Video extends videoCommon.Video {
         this._videoFinished = false;
 
         // subtitles setup
-        this._subtitling = new ASBPlayerSubtitling();
-
-        this._setupSubtitleLabel();
+        if (this.enableSubtitles) {
+            this._subtitling = new ASBPlayerSubtitling();
+    
+            this._setupSubtitleLabel();
+        }
     }
 
     get ios(): any {
@@ -111,10 +113,12 @@ export class Video extends videoCommon.Video {
             this._didPlayToEndTimeActive = true;
         }
 
-        // it's important to set subtitle label first and then player - to let label pick up styles
-        this._subtitling.label = this._subtitleLabel;
-        this._subtitling.containerView = this._subtitleLabelContainer;
-        this._subtitling.player = this._player;
+        if (this.enableSubtitles) {
+            // it's important to set subtitle label first and then player - to let label pick up styles
+            this._subtitling.label = this._subtitleLabel;
+            this._subtitling.containerView = this._subtitleLabelContainer;
+            this._subtitling.player = this._player;
+        }    
     }
 
     private _setupSubtitleLabel(){
@@ -156,12 +160,14 @@ export class Video extends videoCommon.Video {
         contentOverlayView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormatOptionsMetricsViews("V:[subtitleLabelContainer]-(20)-|", 0, null, viewsDictionary));
     }
 
-    private _updateSubtitles(subtitles: NSStirng){
-        try {
-            this._subtitling.loadSRTContentError(subtitles)
-        } catch (e) {
-            console.log("Failed to load subtitles: "+ e); // NSError:
-        }
+    private _updateSubtitles(subtitles: NSString) {
+        if (this.enableSubtitles) {
+            try {
+                this._subtitling.loadSRTContentError(subtitles)
+            } catch (e) {
+                console.log("Failed to load subtitles: " + e); // NSError:
+            }
+        }    
     }
 
     private AVPlayerItemDidPlayToEndTimeNotification(notification: any) {


### PR DESCRIPTION
When orienting video upon play to landscape, users can run into NSContraint issues with the way subtitling was setup here. This defaults subtitles off however adds a new flag, `enableSubtitles` which can easily turn them on.