### PR TITLE
feat(fill): fill property now supports both iOS and Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ node_modules/
 *.stackdump
 src/package*/
 
+package-lock.json
+
 !src/videoplayer.d.ts
 !src/subtitle-source/subtitle-source.d.ts
 !src/video-source/video-source.d.ts

--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -5,14 +5,8 @@
   <ScrollView>
     <StackLayout>
       <Button text="Change Video" tap="{{ changeVideoSource }}" />
-      <GridLayout rows="auto" columns="auto,*,auto,auto" margin="10">
-        <Label text="Current Time: " textWrap="true" />
-        <Label col="1" text="{{ currentTime }}" class="message" textWrap="true" />
-        <Label col="2" text="Video Duration: " textWrap="true" />
-        <Label col="3" text="{{ videoDuration }}" class="message" textWrap="true" />
-      </GridLayout>
       <GridLayout rows="*" columns="*, *" backgroundColor="#000000">
-        <Video:Video id="nativeVideoPlayer" controls="true" loadingComplete="{{ videoCompleted }}" playbackStart="{{ playbackStart }}" finished="{{ videoFinished }}" loop="false" autoplay="true" height="280" src="{{ videoSrc }}" subtitles="{{ subtitlesSrc }}" row="0" colSpan="2"/>
+        <Video:Video id="nativeVideoPlayer" controls="true" loadingComplete="{{ videoCompleted }}" playbackStart="{{ playbackStart }}" finished="{{ videoFinished }}" loop="false" autoplay="true" height="280" fill="{{ videoFill }}" src="{{ videoSrc }}" subtitles="{{ subtitlesSrc }}" row="0" colSpan="2"/>
         <Label text="Label On Top of Video View" row="0" colSpan="2" color="#fff" horizontalAlignment="center"/>
       </GridLayout>
       <StackLayout orientation="horizontal">
@@ -33,6 +27,12 @@
         <Button text="Go to 30 seconds" width="33%" tap="{{ goToTime }}" />
       </StackLayout>
       <Button text="Animate" width="33%" tap="{{ animate }}"/>
+      <GridLayout rows="auto" columns="auto,*,auto,auto" margin="10">
+        <Label text="Current Time: " textWrap="true" />
+        <Label col="1" text="{{ currentTime }}" class="message" textWrap="true" />
+        <Label col="2" text="Video Duration: " textWrap="true" />
+        <Label col="3" text="{{ videoDuration }}" class="message" textWrap="true" />
+      </GridLayout>
     </StackLayout>
   </ScrollView>
 </Page>

--- a/demo/app/main-view-model.ts
+++ b/demo/app/main-view-model.ts
@@ -1,13 +1,15 @@
-import { Observable } from "data/observable";
-import { Page } from "ui/page";
-import { isAndroid } from "platform";
-import { setInterval } from "timer";
+import { Observable } from "tns-core-modules/data/observable";
+import { Page } from "tns-core-modules/ui/page";
+import { isAndroid } from "tns-core-modules/platform";
+import { setInterval } from "tns-core-modules/timer";
+import { VideoFill } from "nativescript-exoplayer";
 
 export class HelloWorldModel extends Observable {
   public videoSrc: string;
   public subtitlesSrc: string;
   public currentTime: any;
   public videoDuration: any;
+  public videoFill: VideoFill = VideoFill.default;
   private _videoPlayer: any;
   private completed: boolean;
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -3,12 +3,15 @@
     "id": "org.nativescript.demo",
     "tns-android": {
       "version": "3.1.1"
+    },
+    "tns-ios": {
+      "version": "5.1.1"
     }
   },
   "dependencies": {
     "nativescript-exoplayer": "file:../src",
     "nativescript-theme-core": "~1.0.2",
-    "tns-core-modules": "^3.1.0",
+    "tns-core-modules": "^5.2.0",
     "tns-platform-declarations": "^5.2.0"
   },
   "devDependencies": {
@@ -16,7 +19,7 @@
     "babel-types": "6.4.5",
     "babylon": "6.4.5",
     "lazy": "1.0.11",
-    "nativescript-dev-typescript": "~0.4.0",
-    "typescript": "~2.2.1"
+    "nativescript-dev-typescript": "~0.8.0",
+    "typescript": "~3.1.6"
   }
 }

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,27 +1,30 @@
 {
-  "compilerOptions": {
-	"module": "commonjs",
-	"target": "es5",
-	"experimentalDecorators": true,
-	"emitDecoratorMetadata": true,
-	"noEmitHelpers": true,
-	"noEmitOnError": true,
-	"allowJs": false,
-	"lib": [
-	  "es6",
-	  "dom"
-	],
-	"baseUrl": ".",
-	"paths": {
-	  "*": [
-		"./node_modules/tns-core-modules/*",
-		"./node_modules/*"
-	  ]
-	}
-  },
-  "exclude": [
-	"node_modules",
-	"platforms",
-	"**/*.aot.ts"
-  ]
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "experimentalDecorators": true,
+        "emitDecoratorMetadata": true,
+        "noEmitHelpers": true,
+        "noEmitOnError": true,
+        "allowJs": false,
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "baseUrl": ".",
+        "paths": {
+            "*": [
+                "./node_modules/tns-core-modules/*",
+                "./node_modules/*"
+            ],
+            "~/*": [
+                "app/*"
+            ]
+        }
+    },
+    "exclude": [
+        "node_modules",
+        "platforms",
+        "**/*.aot.ts"
+    ]
 }

--- a/src/.npmignore
+++ b/src/.npmignore
@@ -20,3 +20,4 @@ README.md
 *.map
 *.stackdump
 package*/
+package-lock.json

--- a/src/README.md
+++ b/src/README.md
@@ -105,9 +105,16 @@ Mutes the native video player.
 
 Sets the native video player to loop once playback has finished.
 
-- **fill - (boolean)** - *optional*  **ANDROID ONLY**
+- **fill - (VideoFill)** - *optional*
 
-If set to true, the aspect ratio of the video will not be honored and it will fill the entire space available.
+Android: When set to VideoFill.aspectFill, the aspect ratio of the video will not be honored and it will fill the entire space available.
+
+iOS: 
+* VideoFill.default = AVLayerVideoGravityResize
+* VideoFill.aspect = AVLayerVideoGravityResizeAspect
+* VideoFill.aspectFill = AVLayerVideoGravityResizeAspectFill
+
+See [here for explanation](https://developer.apple.com/documentation/avfoundation/avlayervideogravity).
 
 - **playbackReady - (function)** - *optional*
 

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,34 +1,12 @@
 {
   "name": "nativescript-exoplayer",
-  "version": "3.4.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "tns-core-modules": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/tns-core-modules/-/tns-core-modules-3.4.1.tgz",
-      "integrity": "sha512-sz/yTmoW7WyDPpr4JEC+trlfiEI14X365jGF//tMCT/G6ISzANr43wc17fgbGH1UA1XbKzujbAl0xPNssRHVUA==",
-      "dev": true,
-      "requires": {
-        "tns-core-modules-widgets": "3.4.0"
-      }
-    },
-    "tns-core-modules-widgets": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/tns-core-modules-widgets/-/tns-core-modules-widgets-3.4.0.tgz",
-      "integrity": "sha512-WEtjDRTjjKB+C1NhY1CJSNyhK9DPCYzBgM+yKgq5AmphK/QdQEMAP1U2ttOv8yWWfsvLZGOnzyLCzcyeoG0Gfw==",
-      "dev": true
-    },
-    "tns-platform-declarations": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/tns-platform-declarations/-/tns-platform-declarations-3.4.1.tgz",
-      "integrity": "sha512-GCvUvmtZ2Nne9GIppYF5xzUQzYP+KF43R+ce9kFMT1erDP0I6thLrRkLEo8JgAYD7ukMqXAb80MlYMv/VDGSCw==",
-      "dev": true
-    },
     "typescript": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+      "version": "file:../demo/node_modules/typescript",
+      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
       "dev": true
     }
   }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-exoplayer",
-  "version": "3.4.2",
+  "version": "4.0.0",
   "main": "videoplayer",
   "typings": "videoplayer.d.ts",
   "description": "A NativeScript plugin that uses the ExoPlayer video player on Android to play local and remote videos.",
@@ -86,6 +86,10 @@
   "readmeFilename": "README.md",
   "scripts": {
     "tsc": "tsc",
-    "prepack": "tsc"
+    "prepack": "tsc",
+    "setup": "cd ../demo && npm i"
+  },
+  "devDependencies": {
+    "typescript": "file:../demo/node_modules/typescript"
   }
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -6,14 +6,15 @@
         "noImplicitAny": false,
         "removeComments": true,
         "preserveConstEnums": true,
-        "declaration": false,
+        "declaration": true,
         "noLib": false,
         "noEmitHelpers": true,
         "experimentalDecorators": true,
         "noEmitOnError": false,
         "lib": [
-            "es6",
-            "dom"
+          "es2017",
+          "dom",
+          "es6"
         ],
         "baseUrl": ".",
         "paths": {
@@ -29,6 +30,7 @@
         "../demo/node_modules/tns-platform-declarations/android.d.ts",
         "../demo/node_modules/tns-platform-declarations/ios.d.ts",
         // sources
+        "videoplayer.d.ts",
         "videoplayer-common.ts",
         "videoplayer.ios.ts",
         "videoplayer.android.ts",

--- a/src/videoplayer-common.ts
+++ b/src/videoplayer-common.ts
@@ -1,10 +1,9 @@
-﻿import videoSource = require("./video-source/video-source");
-import subtitleSource = require("./subtitle-source/subtitle-source");
-import * as definitions from "./videoplayer";
-import { isFileOrResourcePath } from "utils/utils"
-import { isString } from "utils/types"
-import { View, Property, booleanConverter } from "ui/core/view";
-import imageSource = require('image-source');
+﻿import * as videoSource from "./video-source/video-source";
+import * as subtitleSource from "./subtitle-source/subtitle-source";
+import { isFileOrResourcePath } from "tns-core-modules/utils/utils";
+import { isString } from "tns-core-modules/utils/types"
+import { View, Property, booleanConverter } from "tns-core-modules/ui/core/view";
+import * as imageSource from "tns-core-modules/image-source";
 
 // on Android we explicitly set propertySettings to None because android will invalidate its layout (skip unnecessary native call).
 // var AffectsLayout = platform.device.os === platform.platformNames.android ? dependencyObservable.PropertyMetadataSettings.None : dependencyObservable.PropertyMetadataSettings.AffectsLayout;
@@ -72,6 +71,15 @@ function onImgSrcPropertyChanged(view, oldValue, newValue) {
     }
 }
 
+/**
+ * Video aspect/fill handling
+ */
+export enum VideoFill {
+  default = "default",
+  aspect = "aspect",
+  aspectFill = "aspectFill"
+}
+
 export class Video extends View {
     public static finishedEvent: string = "finished";
     public static playbackReadyEvent: string = "playbackReady";
@@ -92,7 +100,7 @@ export class Video extends View {
     public controls: boolean = true; /// set true to enable the media player's playback controls
     public loop: boolean = false; /// whether the video loops the playback after extends
     public muted: boolean = false;
-    public fill: boolean = false;
+    public fill: VideoFill = VideoFill.default;
 
     public static IMAGETYPEMONO = 1;
     public static IMAGETYPESTEREOTOPBOTTOM = 2;
@@ -175,8 +183,7 @@ export const mutedProperty = new Property<Video, boolean>({
 });
 mutedProperty.register(Video);
 
-export const fillProperty = new Property<Video, boolean>({
-    name: "fill",
-    valueConverter: booleanConverter,
+export const fillProperty = new Property<Video, VideoFill>({
+    name: "fill"
 });
 fillProperty.register(Video);

--- a/src/videoplayer.d.ts
+++ b/src/videoplayer.d.ts
@@ -1,104 +1,151 @@
-import { View } from "ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
+export declare enum VideoFill {
+  default = "default",
+  aspect = "aspect",
+  aspectFill = "aspectFill"
+}
 export declare class Video extends View {
+  static finishedEvent: string;
+  static playbackReadyEvent: string;
+  static playbackStartEvent: string;
+  static seekToTimeCompleteEvent: string;
+  static currentTimeUpdatedEvent: string;
+  _emit: any;
   android: any;
   ios: any;
-  src: string; /// video source file
-  loop: boolean; /// whether the video loops the playback after extends
-  autoplay: boolean; /// set true for the video to start playing when ready
-  controls: boolean; /// set true to enable the media player's playback controls
-  _emit: any;
 
   /**
-     * Start playing the video.
-     */
+   * video source file
+   */
+  src: string;
+  imgSrc: string;
+  imgType: number;
+  subtitles: string;
+  subtitleSource: string;
+  observeCurrentTime: boolean;
+
+  /**
+   * set true for the video to start playing when ready
+   */
+  autoplay: boolean;
+
+  /**
+   * set true to enable the media player's playback controls
+   */
+  controls: boolean;
+
+  /**
+   * whether the video loops the playback after extends
+   */
+  loop: boolean;
+  muted: boolean;
+
+  /**
+   * aspect/fill settings
+   * Android: 
+   * When set to VideoFill.aspectFill, the aspect ratio of the video will not be honored and it will fill the entire space available.
+
+   * iOS:
+   * VideoFill.default = AVLayerVideoGravityResize
+   * VideoFill.aspect = AVLayerVideoGravityResizeAspect
+   * VideoFill.aspectFill = AVLayerVideoGravityResizeAspectFill
+   */
+  fill: VideoFill;
+  static IMAGETYPEMONO: number;
+  static IMAGETYPESTEREOTOPBOTTOM: number;
+  static IMAGETYPESTEREOLEFTRIGHT: number;
+
+  /**
+   * Start playing the video.
+   */
   play(): void;
 
   /**
-     * Pause the currently playing video.
-     */
+   * Pause the currently playing video.
+   */
   pause(): void;
 
   /**
-     * Seek the video to a time.
-     * @param {number} time - Time of the video to seek to in milliseconds.
-     */
+   * Seek the video to a time.
+   * @param {number} time - Time of the video to seek to in milliseconds.
+   */
   seekToTime(time: number): void;
 
   /**
-     * Returns the current time of the video duration in milliseconds.
-     * @returns {number} Current time of the video duration.
-     */
+   * Returns the current time of the video duration in milliseconds.
+   * @returns {number} Current time of the video duration.
+   */
   getCurrentTime(): number;
 
   /**
-     * Boolean to determine if observable for current time is registered.
-     * @param {boolean} observeCurrentTime - True to set observable on current time.
-    */
+   * Boolean to determine if observable for current time is registered.
+   * @param {boolean} observeCurrentTime - True to set observable on current time.
+   */
   observeCurrentTime(observeCurrentTime: boolean): void;
 
   /**
-     * Observable for current time of the video duration in milliseconds.
-     * @returns {number} Current time of the video duration.
-    */
+   * Observable for current time of the video duration in milliseconds.
+   * @returns {number} Current time of the video duration.
+   */
   currentTime(): number;
 
   /**
-     * Set the volume of the video
-     * @param {number} volume - Volume to set the video between 0 and 1
-     */
+   * Set the volume of the video
+   * @param {number} volume - Volume to set the video between 0 and 1
+   */
   setVolume(volume: number): void;
 
   /**
-     * Destroy the video player and free up resources.
-     */
+   * Destroy the video player and free up resources.
+   */
   destroy(): void;
 
   /**
-     * Mute and unmute the video.
-     * @param {boolean} mute - true to mute the video, false to unmute.
-     */
+   * Mute and unmute the video.
+   * @param {boolean} mute - true to mute the video, false to unmute.
+   */
   mute(mute: boolean): void;
 
   /**
-     * Returns the duration of the video in milliseconds.
-     * @returns {number} Video duration in milliseconds.
-     */
+   * Returns the duration of the video in milliseconds.
+   * @returns {number} Video duration in milliseconds.
+   */
   getDuration(): number;
 
   /**
-     * *** ANDROID ONLY ***
-     * Stop playback of the video. This resets the player and video src.
-     */
+   * *** ANDROID ONLY ***
+   * Stop playback of the video. This resets the player and video src.
+   */
   stop(): void;
 
   /**
-     * *** IOS ONLY ***
-     * Update the video player with an AVAsset file.
-     */
+   * *** IOS ONLY ***
+   * Update the video player with an AVAsset file.
+   */
   updateAsset(asset): void;
 
   /**
-     * Callback to execute when the video is ready to play
-     * @param {function} callback - The callback function to execute.
-     */
+   * Callback to execute when the video is ready to play
+   * @param {function} callback - The callback function to execute.
+   */
   playbackReady(callback: Function): void;
 
   /**
-     * *** IOS ONLY ***
-     * Callback to execute when the video is playing.
-     * @param {function} callback - The callback function to execute.
-    */
+   * *** IOS ONLY ***
+   * Callback to execute when the video is playing.
+   * @param {function} callback - The callback function to execute.
+   */
   playbackStart(callback: Function): void;
 
   /**
-     * Callback to execute when the video has finished seekToTime.
-     * @param {function} callback - The callback function to execute.
-    */
+   * Callback to execute when the video has finished seekToTime.
+   * @param {function} callback - The callback function to execute.
+   */
   seekToTimeComplete(callback: Function): void;
 
   /**
-    * Callback to execute when the time is updated.
-    * @param {function} callback - The callback function to execute.
-    */
+   * Callback to execute when the time is updated.
+   * @param {function} callback - The callback function to execute.
+   */
   currentTimeUpdated(callback: Function): void;
 }

--- a/src/videoplayer.ios.ts
+++ b/src/videoplayer.ios.ts
@@ -1,7 +1,5 @@
-﻿import videoCommon = require("./videoplayer-common");
-import { ios } from "application"
-import { videoSourceProperty } from "./videoplayer-common";
-import { subtitleSourceProperty } from "./videoplayer-common";
+﻿import { ios } from "tns-core-modules/application";
+import { Video as VideoBase, VideoFill, videoSourceProperty, fillProperty, subtitleSourceProperty } from "./videoplayer-common";
 
 export * from "./videoplayer-common";
 
@@ -15,7 +13,7 @@ declare const
     UILabel,
     CMTimeMake;
 
-export class Video extends videoCommon.Video {
+export class Video extends VideoBase {
     private _player: any; /// AVPlayer
     private _playerController: any; /// AVPlayerViewController
     private _src: string;
@@ -75,6 +73,21 @@ export class Video extends videoCommon.Video {
 
     [videoSourceProperty.setNative](value: AVPlayerItem) {
         this._setNativeVideo(value ? (<any>value).ios : null);
+    }
+
+    [fillProperty.setNative](value: VideoFill) {
+      let videoGravity = AVLayerVideoGravityResize; // default
+      switch (value) {
+        case VideoFill.aspect:
+          videoGravity = AVLayerVideoGravityResizeAspect;
+          break;
+        case VideoFill.aspectFill:
+          videoGravity = AVLayerVideoGravityResizeAspectFill;
+          break;
+      }
+      if (this._playerController) {
+        this._playerController.videoGravity = videoGravity;
+      }
     }
 
     [subtitleSourceProperty.setNative](value: NSString) {
@@ -197,7 +210,7 @@ export class Video extends videoCommon.Video {
         if (this._player.currentItem && this._player.currentItem === notification.object) {
             // This will match exactly to the object from the notification so can ensure only looping and finished event for the video that has finished.
             // Notification is structured like so: NSConcreteNotification 0x61000024f690 {name = AVPlayerItemDidPlayToEndTimeNotification; object = <AVPlayerItem: 0x600000204190, asset = <AVURLAsset: 0x60000022b7a0, URL = https://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4>>}
-            this._emit(videoCommon.Video.finishedEvent);
+            this._emit(VideoBase.finishedEvent);
             this._videoFinished = true;
             if (this.loop === true && this._player !== null) {
                 // Go in 5ms for more seamless looping
@@ -237,7 +250,7 @@ export class Video extends videoCommon.Video {
             let time = CMTimeMakeWithSeconds(seconds, this._player.currentTime().timescale);
             try {
                 this._player.seekToTimeToleranceBeforeToleranceAfterCompletionHandler(time, kCMTimeZero, kCMTimeZero, (isFinished) => {
-                    this._emit(videoCommon.Video.seekToTimeCompleteEvent);
+                    this._emit(VideoBase.seekToTimeCompleteEvent);
                 });
             } catch (e) {
                 console.error(e);
@@ -325,12 +338,12 @@ export class Video extends videoCommon.Video {
 
     playbackReady() {
         this._videoLoaded = true;
-        this._emit(videoCommon.Video.playbackReadyEvent);
+        this._emit(VideoBase.playbackReadyEvent);
     }
 
     playbackStart() {
         this._videoPlaying = true;
-        this._emit(videoCommon.Video.playbackStartEvent);
+        this._emit(VideoBase.playbackStartEvent);
     }
 
 }


### PR DESCRIPTION
This modifies `fill` to support iOS as well by utilizing the `videoGravity` property. See [here for more](https://stackoverflow.com/questions/49105521/avplayer-full-screen-issue-only-for-iphone-x).

In doing so the `fill` property needed to be modified to represent an enum of possible values so Android has been updated as well to account for this. Since this is a breaking change, I have also bumped package to 4.0 in preparation of publishing and added documentation to the README. 

This allows full edge to edge video on iPhoneX largely transforming this (without `fill` support):
<img width="200" alt="screen shot 2019-02-22 at 11 13 44 pm" src="https://user-images.githubusercontent.com/457187/53283720-4db86000-36ff-11e9-910d-fbe9004876eb.png">

To this with `fill` support set to `VideoFill.aspectFill`:
<img width="200" alt="screen shot 2019-02-22 at 11 14 30 pm" src="https://user-images.githubusercontent.com/457187/53283724-590b8b80-36ff-11e9-9df0-96994a8c3e0d.png">

This also updates the plugin to use `tns-core-modules` scoping since with 5.2 the old short imports are going away. Cleaned up couple other things as well.