### PR TITLE
Remove the typing for the observeCurrentTime method

### DIFF
--- a/src/videoplayer.d.ts
+++ b/src/videoplayer.d.ts
@@ -78,12 +78,6 @@ export declare class Video extends View {
   getCurrentTime(): number;
 
   /**
-   * Boolean to determine if observable for current time is registered.
-   * @param {boolean} observeCurrentTime - True to set observable on current time.
-   */
-  observeCurrentTime(observeCurrentTime: boolean): void;
-
-  /**
    * Observable for current time of the video duration in milliseconds.
    * @returns {number} Current time of the video duration.
    */


### PR DESCRIPTION
I removed the typing for the observeCurrentTime method since it doesn't seem to be defined anywhere in the source code & it's a duplicate identifier that prevents typescript compilation when trying to import the Video interface.

Should resolve #40 